### PR TITLE
oops. Dupes fix

### DIFF
--- a/style_editor.html
+++ b/style_editor.html
@@ -10302,8 +10302,7 @@ var inhiltState = new SavedState("inhilt", false, (on) => { STATE_NUM_LEDS = on 
 var slowState = new SavedState("slow", false, (on) => { framesPerUpdate = on ? 60 : 0; });
 
 function onPageLoad() {
-  // THIS IS CAUSING TABS DOUBLING, but without it, createShader is null. Cascade issue likely.
-  // initGL();
+  initGL();
   structuredView = FIND("structured_view");
   all_saved_states.forEach(state => {
     state.onload();

--- a/style_editor.html
+++ b/style_editor.html
@@ -10302,7 +10302,7 @@ var inhiltState = new SavedState("inhilt", false, (on) => { STATE_NUM_LEDS = on 
 var slowState = new SavedState("slow", false, (on) => { framesPerUpdate = on ? 60 : 0; });
 
 function onPageLoad() {
-  // THIS IS CAUSING TABS DOUBLING, but without createShader is null....?
+  // THIS IS CAUSING TABS DOUBLING, but without it, createShader is null. Cascade issue likely.
   // initGL();
   structuredView = FIND("structured_view");
   all_saved_states.forEach(state => {

--- a/style_editor.html
+++ b/style_editor.html
@@ -9936,7 +9936,7 @@ function ActivateTab(tab) {
 </script>
 </head>
 
-<body onload="initGL()">
+<body>
 
   <table>
   <tr>

--- a/style_editor.html
+++ b/style_editor.html
@@ -10302,7 +10302,8 @@ var inhiltState = new SavedState("inhilt", false, (on) => { STATE_NUM_LEDS = on 
 var slowState = new SavedState("slow", false, (on) => { framesPerUpdate = on ? 60 : 0; });
 
 function onPageLoad() {
-  initGL();
+  // THIS IS CAUSING TABS DOUBLING, but without createShader is null....?
+  // initGL();
   structuredView = FIND("structured_view");
   all_saved_states.forEach(state => {
     state.onload();


### PR DESCRIPTION
Currently, calling initGL() in the onPageLoad function is causing duplicate tabs to be created...makes sense somewhat since initGL() is already called just above all the HTML.
Removing it like this commit does fixes the duplicate tabs, but the page gets an error in the console that createShader is null. (in the compile() function)
In my local version of the Style Editor which I've been picking from, adding the call to initGL() in onPageLoad fixed THAT problem without causing the duplicates problem, so it must have to do with the order of code (I've moved blocks around to keep scripts near associated HTML) 

TL;DR, this is a lesser-of-2-evils patch since 2 sets of tabs looks goofy and is wrong of course, while the createShader issue doesn't show up as any noticeable problem (Graflex hilt is rendered fine) and seems to be resolved down the line as further PRs are submitted.
A second pair of eyes would be helpful if it needs to be resolved right now , but eventually I think it'll be fine.