### PR TITLE
remove NoisySoundLevelCompat from buttons

### DIFF
--- a/style_editor.html
+++ b/style_editor.html
@@ -3077,7 +3077,6 @@ AddFunction("BlinkingF<Int<1000>, Int<500>>");
 AddFunction("BrownNoiseF<Int<50>>");
 AddFunction("HumpFlickerF<50>");
 AddFunction("NoisySoundLevel");
-AddFunction("NoisySoundLevelCompat");
 AddFunction("SmoothSoundLevel");
 AddFunction("SwingSpeed<250>");
 AddFunction("SwingAcceleration<130>");


### PR DESCRIPTION
This is really just an under-the-hood thing to drive AudioFlicker, right?
Just normal NoisySoundLevel is what the user should see?