### PR TITLE
Fix Increment Function bug

### DIFF
--- a/style_editor.html
+++ b/style_editor.html
@@ -1828,9 +1828,6 @@ function Arg(expected_type, arg, default_arg) {
   if (typeof(arg) != "number" && arg.getType() != expected_type) {
     throw "Expected " + expected_type + " but got " + arg;
   }
-  if (expected_type == "INT" && typeof(arg) == "number") {
-    return new INTEGER(arg);
-  }
   if (expected_type == "INT" || expected_type == "EFFECT" || expected_type == "LOCKUP_TYPE" || expected_type == "ArgumentName") {
     return arg;
   }


### PR DESCRIPTION
The removed code was resetting Increment functions to 0 immediately, preventing expected behavior.

Removed:
  if (expected_type == "INT" && typeof(arg) == "number") {
    return new INTEGER(arg);
  }