### PR TITLE
Fix Saw

### DIFF
--- a/style_editor.html
+++ b/style_editor.html
@@ -7476,9 +7476,9 @@ class SawClass extends FUNCTION {
     this.pos = fract(this.pos + delta / 60000000.0 * this.RPM.getInteger(0));
     var high = this.HIGH.getInteger(0);
     var low = this.LOW.getInteger(0);
-    this.value = low + this.pos * (high - low);
+    this.value = Math.floor(low + this.pos * (high - low));
   }
-  getInteger(led) { return Math.floor(this.value); }
+  getInteger(led) { return this.value; }
 };
 
 function Saw(RPM, LOW, HIGH) { return new SawClass(RPM, LOW, HIGH); }

--- a/style_editor.html
+++ b/style_editor.html
@@ -7478,7 +7478,7 @@ class SawClass extends FUNCTION {
     var low = this.LOW.getInteger(0);
     this.value = low + this.pos * (high - low);
   }
-  getInteger(led) { return this.value; }
+  getInteger(led) { return Math.floor(this.value); }
 };
 
 function Saw(RPM, LOW, HIGH) { return new SawClass(RPM, LOW, HIGH); }


### PR DESCRIPTION
Would freeze the page if used in ColorSelect<> as an example.

`ColorSelect<Saw<Int<30>,Int<3>>,TrInstant,Red,Green,Blue>`
