### PR TITLE
Fix TrDoEffectAlwaysX - add defaults for WavNum and Location

### DIFF
--- a/style_editor.html
+++ b/style_editor.html
@@ -6964,8 +6964,8 @@ class TrDoEffectAlwaysXClass extends TRANSITION {
     super("Do effect", arguments);
     this.add_arg("TRANSITION","TRANSITION", "Wrapped transition");
     this.add_arg("EFFECT", "EFFECT", "Effect to trigger.");
-    this.add_arg("WAVNUM", "FUNCTION", "Select wave number.");
-    this.add_arg("LOCATION", "FUNCTION", "Effect location.");
+    this.add_arg("WAVNUM", "FUNCTION", "Select wave number.", Int(-1));
+    this.add_arg("LOCATION", "FUNCTION", "Effect location.", Int(-1));
     this.begin_ = false;
   }
   begin() {


### PR DESCRIPTION
This works now with this change.
However, I am unsure if the line `blade.addEffect(this.EFFECT, location)` needs to also change?
As per PR #71,  it became `blade.addEffect(this.EFFECT.value, location)`.
I don't quite understand the expectation here... is it a wrapped EFFECT something...?